### PR TITLE
Not to generate hashes for initrd or modules if module.sig_enforce=1 …

### DIFF
--- a/initrd/bin/kexec-boot
+++ b/initrd/bin/kexec-boot
@@ -6,8 +6,9 @@ set -e -o pipefail
 
 dryrun="n"
 printfiles="n"
+printfilestohash="n"
 printinitrd="n"
-while getopts "b:e:r:a:o:fi" arg; do
+while getopts "b:e:r:a:o:fhi" arg; do
 	case $arg in
 		b) bootdir="$OPTARG" ;;
 		e) entry="$OPTARG" ;;
@@ -15,6 +16,7 @@ while getopts "b:e:r:a:o:fi" arg; do
 		a) cmdadd="$OPTARG" ;;
 		o) override_initrd="$OPTARG" ;;
 		f) dryrun="y"; printfiles="y" ;;
+		h) dryrun="y"; printfilestohash="y" ;;
 		i) dryrun="y"; printinitrd="y" ;;
 	esac
 done
@@ -32,12 +34,12 @@ kexeccmd="kexec"
 cmdadd="$CONFIG_BOOT_KERNEL_ADD $cmdadd"
 cmdremove="$CONFIG_BOOT_KERNEL_REMOVE $cmdremove"
 
-fix_file_path() {
-	if [ "$printfiles" = "y" ]; then
-		# output file relative to local boot directory
-		echo ".$firstval"
-	fi
+printfilename() {
+	# output filename relative to local boot directory
+	echo ".$firstval"
+}
 
+fix_file_path() {
 	filepath="$bootdir$firstval"
 
 	if ! [ -r $filepath ]; then
@@ -59,6 +61,17 @@ adjust_cmd_line() {
 	adjusted_cmd_line="y"
 }
 
+hash_modules="y"
+if [ "$CONFIG_BOOT_RESPECT_MOD_SIG_ENFORCE" = "y" ]; then
+	# check whether "module.sig_enforce=1" present
+	# in the "append" line
+	if grep -q '^append.*\ module.sig_enforce=1'; then
+		hash_modules="n"
+	fi << EOF
+$kexecparams
+EOF
+fi
+
 module_number="1"
 while read line
 do
@@ -72,15 +85,31 @@ do
 			kexeccmd="$kexeccmd --command-line \"no-real-mode reboot=no vga=current\""
 		elif [ "$kexectype" = "multiboot" ]; then
 			fix_file_path
+			if [ "$printfiles" = "y" \
+				-o "$printfilestohash" = "y" ] \
+			; then
+				printfilename
+			fi
 			kexeccmd="$kexeccmd -l $filepath"
 			kexeccmd="$kexeccmd --command-line \"$restval\""
 		else
 			fix_file_path
+			if [ "$printfiles" = "y" \
+				-o "$printfilestohash" = "y" ] \
+			; then
+				printfilename
+			fi
 			kexeccmd="$kexeccmd -l $filepath"
 		fi
 	fi
 	if [ "$key" = "module" ]; then
 		fix_file_path
+		if [ "$printfiles" = "y" \
+				-o "$printfilestohash" = "y" \
+				-a "$hash_modules" = "y" ] \
+		; then
+				printfilename
+		fi
 		cmdline="$restval"
 		if [ "$kexectype" = "xen" ]; then
 			if [ "$module_number" -eq 1 ]; then
@@ -100,6 +129,12 @@ do
 	fi
 	if [ "$key" = "initrd" ]; then
 		fix_file_path
+		if [ "$printfiles" = "y" \
+				-o "$printfilestohash" = "y" \
+				-a "$hash_modules" = "y" ] \
+		; then
+				printfilename
+		fi
 		if [ "$printinitrd" = "y" ]; then
 			# output the current path to initrd
 			echo $filepath

--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -118,7 +118,7 @@ if [ ! -d $paramsdir ]; then
 fi
 rm "$paramsdir/kexec_default.*.txt" 2>/dev/null || true
 echo "$entry" > $ENTRY_FILE
-cd $bootdir && kexec-boot -b "$bootdir" -e "$entry" -f | \
+cd $bootdir && kexec-boot -b "$bootdir" -e "$entry" -h | \
 	xargs sha256sum > $HASH_FILE \
 || die "Failed to create hashes of boot files"
 if [ ! -r $ENTRY_FILE -o ! -r $HASH_FILE ]; then


### PR DESCRIPTION
…is present

Digital signatures could be embedded into linux kernel modules, and a kernel
with a certificate embedded in can load them only if their signature is valid,
when booted with parameter "module.sig_enforce=1" present.

In such situation, for bootloader (e.g. Heads) to verify the hashes of initrd
or modules may become unnecessary, and leaving them to the kernel may ease the
updating of initrd from GNU/Linux OSes.

Option CONFIG_BOOT_RESPECT_MOD_SIG_ENFORCE is used to enable this feature.

Test passed on my x230 atop flammit's coreboot-4.6 branch.