### PR TITLE
Make TPM dependency optional and controlled by flag CONFIG_TPM

### DIFF
--- a/initrd/bin/kexec-save-default
+++ b/initrd/bin/kexec-save-default
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Save these options to be the persistent default
 set -e -o pipefail
+. /etc/config
 . /etc/functions
 
 while getopts "b:d:p:i:" arg; do
@@ -44,69 +45,72 @@ fi
 KEY_DEVICES="$paramsdir/kexec_key_devices.txt"
 KEY_LVM="$paramsdir/kexec_key_lvm.txt"
 save_key="n"
-if [ ! -r "$KEY_DEVICES" ]; then
-	read \
-		-n 1 \
-		-p "Do you wish to add a disk encryption to the TPM [y/N]: " \
-		add_key_confirm
-	echo
+if [ "$CONFIG_TPM" != "n" ]; then
+	if [ ! -r "$KEY_DEVICES" ]; then
+		read \
+			-n 1 \
+			-p "Do you wish to add a disk encryption to the TPM [y/N]: " \
+			add_key_confirm
+		echo
 
-	if [ "$add_key_confirm" = "y" \
-		-o "$add_key_confirm" = "Y" ] \
-	; then
-		lvm_suggest="e.g. qubes_dom0 or blank"
-		devices_suggest="e.g. /dev/sda2 or blank"
-		save_key="y"
-	fi
-else
-	read \
-		-n 1 \
-		-p "Do you want to reseal a disk key to the TPM [y/N]: " \
-		change_key_confirm
-	echo
-
-	if [ "$change_key_confirm" = "y" \
-		-o "$change_key_confirm" = "Y" ] \
-	; then
-		old_lvm_volume_group=""
-		if [ -r "$KEY_LVM" ]; then
-			old_lvm_volume_group=`cat $KEY_LVM` || true
-			old_key_devices=`cat $KEY_DEVICES | cut -d\  -f1 \
-				| grep -v "$old_lvm_volume_group" | xargs` || true
-		else
-			old_key_devices=`cat $KEY_DEVICES | cut -d\  -f1 | xargs` || true
+		if [ "$add_key_confirm" = "y" \
+			-o "$add_key_confirm" = "Y" ]; then
+			lvm_suggest="e.g. qubes_dom0 or blank"
+			devices_suggest="e.g. /dev/sda2 or blank"
+			save_key="y"
 		fi
-
-		lvm_suggest="was '$old_lvm_volume_group'"
-		devices_suggest="was '$old_key_devices'"
-		save_key="y"
-	fi
-fi
-
-if [ "$save_key" = "y" ]; then
-	echo "+++ LVM volume groups (lvm vgscan): "
-	lvm vgscan || true
-
-	read \
-		-p "Encrypted LVM group? ($lvm_suggest): " \
-		lvm_volume_group
-
-	echo "+++ Block devices (blkid): "
-	blkid || true
-
-	read \
-		-p "Encrypted devices? ($devices_suggest): " \
-		key_devices
-
-	save_key_params="-s -p $paramsdev"
-	if [ -n "$lvm_volume_group" ]; then
-		save_key_params="$save_key_params -l $lvm_volume_group $key_devices"
 	else
-		save_key_params="$save_key_params $key_devices"
+		read \
+			-n 1 \
+			-p "Do you want to reseal a disk key to the TPM [y/N]: " \
+			change_key_confirm
+		echo
+
+		if [ "$change_key_confirm" = "y" \
+			-o "$change_key_confirm" = "Y" ]; then
+			old_lvm_volume_group=""
+			if [ -r "$KEY_LVM" ]; then
+				old_lvm_volume_group=`cat $KEY_LVM` || true
+				old_key_devices=`cat $KEY_DEVICES \
+				| cut -d\  -f1 \
+				| grep -v "$old_lvm_volume_group" \
+				| xargs` || true
+			else
+				old_key_devices=`cat $KEY_DEVICES \
+				| cut -d\  -f1 | xargs` || true
+			fi
+
+			lvm_suggest="was '$old_lvm_volume_group'"
+			devices_suggest="was '$old_key_devices'"
+			save_key="y"
+		fi
 	fi
-	echo "Running kexec-save-key with params: $save_key_params"
-	kexec-save-key $save_key_params \
-	|| die "Failed to save the disk key"
+
+	if [ "$save_key" = "y" ]; then
+		echo "+++ LVM volume groups (lvm vgscan): "
+		lvm vgscan || true
+
+		read \
+			-p "Encrypted LVM group? ($lvm_suggest): " \
+			lvm_volume_group
+
+		echo "+++ Block devices (blkid): "
+		blkid || true
+
+		read \
+			-p "Encrypted devices? ($devices_suggest): " \
+			key_devices
+
+		save_key_params="-s -p $paramsdev"
+		if [ -n "$lvm_volume_group" ]; then
+			save_key_params="$save_key_params -l $lvm_volume_group $key_devices"
+		else
+			save_key_params="$save_key_params $key_devices"
+		fi
+		echo "Running kexec-save-key with params: $save_key_params"
+		kexec-save-key $save_key_params \
+			|| die "Failed to save the disk key"
+	fi
 fi
 
 # try to switch to rw mode
@@ -126,7 +130,11 @@ if [ ! -r $ENTRY_FILE -o ! -r $HASH_FILE ]; then
 fi
 
 # sign and auto-roll config counter
-kexec-sign-config -p $paramsdir -u \
+extparam=
+if [ "$CONFIG_TPM" != "n" ]; then
+	extparam=-u
+fi
+kexec-sign-config -p $paramsdir $extparam \
 || die "Failed to sign default config"
 
 # switch back to ro mode

--- a/initrd/bin/kexec-select-boot
+++ b/initrd/bin/kexec-select-boot
@@ -232,7 +232,8 @@ do_boot()
 		die "!!! Missing required boot hashes"
 	fi
 
-	if [ -r "$TMP_KEY_DEVICES" ]; then
+	if [ "$CONFIG_TPM" != "n" \
+		-a -r "$TMP_KEY_DEVICES" ]; then
 		INITRD=`kexec-boot -b "$bootdir" -e "$option" -i` \
 		|| die "!!! Failed to extract the initrd from boot option"
 		if [ -z "$INITRD" ]; then
@@ -261,7 +262,8 @@ while true; do
 	TMP_KEY_DEVICES="/tmp/kexec/kexec_key_devices.txt"
 	TMP_KEY_LVM="/tmp/kexec/kexec_key_lvm.txt"
 
-	if [ ! -r "$TMP_KEY_DEVICES" ]; then
+	if [ "$CONFIG_TPM" != "n" \
+		-a ! -r "$TMP_KEY_DEVICES" ]; then
 		# Extend PCR4 as soon as possible
 		tpm extend -ix 4 -ic generic \
 		|| die "Failed to extend PCR 4"
@@ -272,22 +274,24 @@ while true; do
 		scan_options
 	fi
 
-	# Optionally enforce device file hashes
-	if [ -r "$TMP_HASH_FILE" ]; then
-		valid_global_hash="n"
+	if [ "$CONFIG_TPM" != "n" ]; then
+		# Optionally enforce device file hashes
+		if [ -r "$TMP_HASH_FILE" ]; then
+			valid_global_hash="n"
 
-		verify_global_hashes
+			verify_global_hashes
 
-		if [ "$valid_global_hash" = "n" ]; then
-			die "Failed to verify global hashes"
+			if [ "$valid_global_hash" = "n" ]; then
+				die "Failed to verify global hashes"
+			fi
 		fi
-	fi
 
-	if [ -r "$TMP_ROLLBACK_FILE" ]; then
-		# in the case of iso boot with a rollback file, do not assume valid
-		valid_rollback="n"
+		if [ -r "$TMP_ROLLBACK_FILE" ]; then
+			# in the case of iso boot with a rollback file, do not assume valid
+			valid_rollback="n"
 
-		verify_rollback_counter
+			verify_rollback_counter
+		fi
 	fi
 
 	if [ "$default_failed" != "y" \

--- a/initrd/bin/usb-init
+++ b/initrd/bin/usb-init
@@ -4,8 +4,10 @@
 . /etc/functions
 . /etc/config
 
-# Extend PCR4 as soon as possible
-tpm extend -ix 4 -ic usb
+if [ "$CONFIG_TPM" != "n" ]; then
+	# Extend PCR4 as soon as possible
+	tpm extend -ix 4 -ic usb
+fi
 
 usb-scan
 recovery "Something failed during USB boot"

--- a/initrd/etc/functions
+++ b/initrd/etc/functions
@@ -17,8 +17,9 @@ recovery() {
 	# but recreate the directory so that new tools can use it.
 	rm -rf /tmp/secret
 	mkdir -p /tmp/secret
-	tpm extend -ix 4 -ic recovery
-
+	if [ "$CONFIG_TPM" != n ]; then
+		tpm extend -ix 4 -ic recovery
+	fi
 	echo >&2 "!!!!! Starting recovery shell"
 	sleep 1
 	exec /bin/ash


### PR DESCRIPTION
if "CONFIG_TPM=n" is set in the config file, functionalities needing TPM
could be disabled, while leaving other functionalities intact.

This will make Heads a more general-usage bootloader payload atop coreboot.